### PR TITLE
Fixing .mget() implementation.

### DIFF
--- a/lib/MockRedisClient.js
+++ b/lib/MockRedisClient.js
@@ -40,8 +40,8 @@ var MockRedisClient = function() {
         var cb = function(err, value) {
             if (err) throw err;
 
-            if (value) {
-                values.push( value );
+            if (value || value === null) {
+                values.unshift( value );
             }
 
             var key = keys.pop();

--- a/test/MockRedisClientTests.js
+++ b/test/MockRedisClientTests.js
@@ -37,7 +37,7 @@ describe('MockRedisClient', function() {
         it('should have all known methods by count', function() {
             var methods = dash.methods( mock );
 
-            methods.length.should.equal( 123 );
+            methods.length.should.equal( 127 );
         });
     });
 


### PR DESCRIPTION
Fixing the following `.mget()` issues:
- Values returned should be in the same order as the requested keys
- Keys not found should return `null`

@darrylwest @raincity 
